### PR TITLE
Ensures core protocol imports are consistent with its package naming

### DIFF
--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -5,16 +5,15 @@ pragma solidity ^0.8.23;
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-// solhint-disable-next-line max-line-length
-import { PILPolicy, PILPolicyFrameworkManager, RegisterPILPolicyParams } from "@storyprotocol/contracts/modules/licensing/PILPolicyFrameworkManager.sol";
-import { BaseModule } from "@storyprotocol/contracts/modules/BaseModule.sol";
-import { IPAssetRegistry } from "@storyprotocol/contracts/registries/IPAssetRegistry.sol";
-import { ILicensingModule } from "@storyprotocol/contracts/interfaces/modules/licensing/ILicensingModule.sol";
-import { IP } from "@storyprotocol/contracts/lib/IP.sol";
-import { IPResolver } from "@storyprotocol/contracts/resolvers/IPResolver.sol";
-import { IIPAccount } from "@storyprotocol/contracts/interfaces/IIPAccount.sol";
-import { AccessPermission } from "@storyprotocol/contracts/lib/AccessPermission.sol";
-import { IAccessController } from "@storyprotocol/contracts/interfaces/IAccessController.sol";
+import { PILPolicy, PILPolicyFrameworkManager, RegisterPILPolicyParams } from "@story-protocol/protocol-core/contracts/modules/licensing/PILPolicyFrameworkManager.sol";
+import { BaseModule } from "@story-protocol/protocol-core/contracts/modules/BaseModule.sol";
+import { IPAssetRegistry } from "@story-protocol/protocol-core/contracts/registries/IPAssetRegistry.sol";
+import { ILicensingModule } from "@story-protocol/protocol-core/contracts/interfaces/modules/licensing/ILicensingModule.sol";
+import { IP } from "@story-protocol/protocol-core/contracts/lib/IP.sol";
+import { IPResolver } from "@story-protocol/protocol-core/contracts/resolvers/IPResolver.sol";
+import { IIPAccount } from "@story-protocol/protocol-core/contracts/interfaces/IIPAccount.sol";
+import { AccessPermission } from "@story-protocol/protocol-core/contracts/lib/AccessPermission.sol";
+import { IAccessController } from "@story-protocol/protocol-core/contracts/interfaces/IAccessController.sol";
 
 import { SPG } from "./lib/SPG.sol";
 import { Metadata } from "./lib/Metadata.sol";

--- a/contracts/interfaces/IStoryProtocolGateway.sol
+++ b/contracts/interfaces/IStoryProtocolGateway.sol
@@ -2,7 +2,7 @@
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
 pragma solidity ^0.8.23;
 
-import { IModule } from "@storyprotocol/contracts/interfaces/modules/base/IModule.sol";
+import { IModule } from "@story-protocol/protocol-core/contracts/interfaces/modules/base/IModule.sol";
 
 import { IStoryProtocolDrop } from "./IStoryProtocolDrop.sol";
 import { Metadata } from "../lib/Metadata.sol";

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,7 +1,6 @@
 @ensdomains/=node_modules/@ensdomains/
 @openzeppelin/=node_modules/@openzeppelin/
-@storyprotocol/=node_modules/@story-protocol/protocol-core/
-@storyprotocol-old/=node_modules/@storyprotocol/contracts-old/
+@story-protocol/protocol-core/=node_modules/@story-protocol/protocol-core/
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 hardhat/=node_modules/hardhat/

--- a/script/Main.s.sol
+++ b/script/Main.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import { IPAssetRegistry } from "@storyprotocol/contracts/registries/IPAssetRegistry.sol";
+import { IPAssetRegistry } from "@story-protocol/protocol-core/contracts/registries/IPAssetRegistry.sol";
 
 import { console2 } from "forge-std/console2.sol";
 import { Script } from "forge-std/Script.sol";

--- a/test/StoryProtocolGateway.t.sol
+++ b/test/StoryProtocolGateway.t.sol
@@ -3,17 +3,19 @@ pragma solidity ^0.8.23;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import { IPAssetRegistry } from "@storyprotocol/contracts/registries/IPAssetRegistry.sol";
-import { ILicensingModule } from "@storyprotocol/contracts/interfaces/modules/licensing/ILicensingModule.sol";
-import { IRoyaltyPolicyLAP } from "@storyprotocol/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol";
-import { AccessPermission } from "@storyprotocol/contracts/lib/AccessPermission.sol";
-import { MetaTx } from "@storyprotocol/contracts/lib/MetaTx.sol";
-import { ModuleRegistry } from "@storyprotocol/contracts/registries/ModuleRegistry.sol";
-// solhint-disable-next-line max-line-length
-import { PILPolicy, IPILPolicyFrameworkManager, RegisterPILPolicyParams } from "@storyprotocol/contracts/interfaces/modules/licensing/IPILPolicyFrameworkManager.sol";
-import { AccessController } from "@storyprotocol/contracts/AccessController.sol";
+import { IPAssetRegistry } from "@story-protocol/protocol-core/contracts/registries/IPAssetRegistry.sol";
+import { LicensingModule } from "@story-protocol/protocol-core/contracts/modules/licensing/LicensingModule.sol";
+import { ILicensingModule } from "@story-protocol/protocol-core/contracts/interfaces/modules/licensing/ILicensingModule.sol";
+import { IRoyaltyPolicyLAP } from "@story-protocol/protocol-core/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol";
+import { AccessPermission } from "@story-protocol/protocol-core/contracts/lib/AccessPermission.sol";
+import { MetaTx } from "@story-protocol/protocol-core/contracts/lib/MetaTx.sol";
+import { ModuleRegistry } from "@story-protocol/protocol-core/contracts/registries/ModuleRegistry.sol";
+import { PILPolicy, IPILPolicyFrameworkManager, RegisterPILPolicyParams } from "@story-protocol/protocol-core/contracts/interfaces/modules/licensing/IPILPolicyFrameworkManager.sol";
+import { IP } from "@story-protocol/protocol-core/contracts/lib/IP.sol";
+import { AccessController } from "@story-protocol/protocol-core/contracts/AccessController.sol";
 import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
-import { IPResolver } from "@storyprotocol/contracts/resolvers/IPResolver.sol";
+import { IPResolver } from "@story-protocol/protocol-core/contracts/resolvers/IPResolver.sol";
+import { KeyValueResolver } from "@story-protocol/protocol-core/contracts/resolvers/KeyValueResolver.sol";
 
 import { MockERC721Cloneable } from "./mocks/nft/MockERC721Cloneable.sol";
 import { StoryProtocolCoreAddressManager } from "script/utils/StoryProtocolCoreAddressManager.sol";


### PR DESCRIPTION
We need to standardize how imports and remappings of our core protocol and periphery contracts are done. This PR ensures that imports of core protocol code is consistent with the protocol-core package naming.

In the future, any example import references (e.g. in our docs) should be consistent with this as well.