### PR TITLE
Enforces use of relative imports in all main contracts

### DIFF
--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -5,9 +5,11 @@ pragma solidity ^0.8.23;
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+// solhint-disable-next-line
 import { PILPolicy, PILPolicyFrameworkManager, RegisterPILPolicyParams } from "@story-protocol/protocol-core/contracts/modules/licensing/PILPolicyFrameworkManager.sol";
 import { BaseModule } from "@story-protocol/protocol-core/contracts/modules/BaseModule.sol";
 import { IPAssetRegistry } from "@story-protocol/protocol-core/contracts/registries/IPAssetRegistry.sol";
+// solhint-disable-next-line
 import { ILicensingModule } from "@story-protocol/protocol-core/contracts/interfaces/modules/licensing/ILicensingModule.sol";
 import { IP } from "@story-protocol/protocol-core/contracts/lib/IP.sol";
 import { IPResolver } from "@story-protocol/protocol-core/contracts/resolvers/IPResolver.sol";

--- a/contracts/nft/ERC721Cloneable.sol
+++ b/contracts/nft/ERC721Cloneable.sol
@@ -5,7 +5,8 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import { Errors } from "contracts/lib/Errors.sol";
+
+import { Errors } from "../lib/Errors.sol";
 
 /// @title Minimal ERC-721 Cloneable Contract
 /// @notice Minimal cloneable ERC-721 contract supporting the metadata extension.

--- a/contracts/nft/ERC721MetadataProvider.sol
+++ b/contracts/nft/ERC721MetadataProvider.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.23;
 
 import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
-
-import { IERC721SPNFT } from "contracts/interfaces/nft/IERC721SPNFT.sol";
-import { IERC721MetadataProvider } from "contracts/interfaces/nft/IERC721MetadataProvider.sol";
-import { Metadata } from "contracts/lib/Metadata.sol";
-import { Errors } from "contracts/lib/Errors.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import { IERC721SPNFT } from "../interfaces/nft/IERC721SPNFT.sol";
+import { IERC721MetadataProvider } from "../interfaces/nft/IERC721MetadataProvider.sol";
+import { Metadata } from "../lib/Metadata.sol";
+import { Errors } from "../lib/Errors.sol";
 
 /// @title ERC-721 Metadata Provider
 /// @notice Contract for storing ERC-721 JSON compliant metadata.

--- a/contracts/nft/ERC721SPNFT.sol
+++ b/contracts/nft/ERC721SPNFT.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 
-import { IERC721MetadataProvider } from "..//interfaces/nft/IERC721MetadataProvider.sol";
+import { IERC721MetadataProvider } from "../interfaces/nft/IERC721MetadataProvider.sol";
 import { ERC721Cloneable } from "./ERC721Cloneable.sol";
 import { Errors } from "../lib/Errors.sol";
 import { SPG } from "../lib/SPG.sol";

--- a/contracts/nft/ERC721SPNFTFactory.sol
+++ b/contracts/nft/ERC721SPNFTFactory.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.23;
 
 import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
+
 import { ERC721SPNFT } from "./ERC721SPNFT.sol";
 import { ERC721MetadataProvider } from "./ERC721MetadataProvider.sol";
 import { SPG } from "../lib/SPG.sol";

--- a/test/StoryProtocolGateway.t.sol
+++ b/test/StoryProtocolGateway.t.sol
@@ -4,18 +4,18 @@ pragma solidity ^0.8.23;
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import { IPAssetRegistry } from "@story-protocol/protocol-core/contracts/registries/IPAssetRegistry.sol";
-import { LicensingModule } from "@story-protocol/protocol-core/contracts/modules/licensing/LicensingModule.sol";
+// solhint-disable-next-line
 import { ILicensingModule } from "@story-protocol/protocol-core/contracts/interfaces/modules/licensing/ILicensingModule.sol";
+// solhint-disable-next-line
 import { IRoyaltyPolicyLAP } from "@story-protocol/protocol-core/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol";
 import { AccessPermission } from "@story-protocol/protocol-core/contracts/lib/AccessPermission.sol";
 import { MetaTx } from "@story-protocol/protocol-core/contracts/lib/MetaTx.sol";
 import { ModuleRegistry } from "@story-protocol/protocol-core/contracts/registries/ModuleRegistry.sol";
+// solhint-disable-next-line
 import { PILPolicy, IPILPolicyFrameworkManager, RegisterPILPolicyParams } from "@story-protocol/protocol-core/contracts/interfaces/modules/licensing/IPILPolicyFrameworkManager.sol";
-import { IP } from "@story-protocol/protocol-core/contracts/lib/IP.sol";
 import { AccessController } from "@story-protocol/protocol-core/contracts/AccessController.sol";
 import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
 import { IPResolver } from "@story-protocol/protocol-core/contracts/resolvers/IPResolver.sol";
-import { KeyValueResolver } from "@story-protocol/protocol-core/contracts/resolvers/KeyValueResolver.sol";
 
 import { MockERC721Cloneable } from "./mocks/nft/MockERC721Cloneable.sol";
 import { StoryProtocolCoreAddressManager } from "script/utils/StoryProtocolCoreAddressManager.sol";


### PR DESCRIPTION
This PR ensures all core contracts use relative imports to ensure no external contracts using it as a dependency run into remappings issues.